### PR TITLE
Migrado a JdeRobot 4.3 satisfactoriamente

### DIFF
--- a/AndroidCameraServer/.classpath
+++ b/AndroidCameraServer/.classpath
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="com.android.ide.eclipse.adt.ANDROID_FRAMEWORK"/>
-	<classpathentry kind="con" path="com.android.ide.eclipse.adt.LIBRARIES"/>
+	<classpathentry exported="true" kind="con" path="com.android.ide.eclipse.adt.LIBRARIES"/>
 	<classpathentry exported="true" kind="con" path="com.android.ide.eclipse.adt.DEPENDENCIES"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="src" path="generated"/>
 	<classpathentry kind="src" path="gen"/>
 	<classpathentry kind="lib" path="libs/Ice.jar"/>
+	<classpathentry kind="con" path="com.android.ide.eclipse.adt.ANDROID_FRAMEWORK"/>
 	<classpathentry kind="output" path="bin/classes"/>
 </classpath>

--- a/AndroidCameraServer/project.properties
+++ b/AndroidCameraServer/project.properties
@@ -11,4 +11,4 @@
 #proguard.config=${sdk.dir}/tools/proguard/proguard-android.txt:proguard-project.txt
 
 # Project target.
-target=Google Inc.:Google APIs (x86 System Image):19
+target=android-17

--- a/AndroidCameraServer/src/com/linaresdigital/android/androidcameraserver/CameraI.java
+++ b/AndroidCameraServer/src/com/linaresdigital/android/androidcameraserver/CameraI.java
@@ -32,9 +32,9 @@ public class CameraI extends jderobot._CameraDisp {
 	 */
 	private static final long serialVersionUID = 1L;
 
-	CameraDescription descripcion;
-	
-	CameraI() {
+    CameraDescription descripcion;
+    
+    CameraI() {
 		descripcion = new CameraDescription();
 		descripcion.name = "Android";
 		/* Inicializamos la descripción de la imagen */
@@ -50,17 +50,15 @@ public class CameraI extends jderobot._CameraDisp {
 		idImagen.timeStamp.seconds = 0;
 		idImagen.timeStamp.useconds = 0;
 	}
-	
+    
 	@Override
 	public CameraDescription getCameraDescription(Current __current) {
-		// TODO Auto-generated method stub
 		return descripcion;
 	}
 
 	@Override
 	public int setCameraDescription(CameraDescription description,
 			Current __current) {
-		// TODO Auto-generated method stub
 		descripcion = description;
 		return 0;
 	}
@@ -76,7 +74,13 @@ public class CameraI extends jderobot._CameraDisp {
 		// TODO Auto-generated method stub
 		
 	}
-	
+
+	@Override
+	public void reset(Current __current) {
+		// TODO Auto-generated method stub
+		
+	}
+
 	/**
 	 * Entrega la descripción de la imagen.
 	 * @return Datos de la descripción de la imagen
@@ -112,9 +116,4 @@ public class CameraI extends jderobot._CameraDisp {
 	    private AMD_ImageProvider_getImageData cb;
 	}
 
-	@Override
-	public void reset(Current __current) {
-		// TODO Auto-generated method stub
-		
-	}
 }


### PR DESCRIPTION
Problemas con la versión anterior de AndroidCameraServer que mostraban este mensaje en el cliente (cameraview o opencvdemo):

```
ICE error: Outgoing.cpp:499: Ice::UnknownLocalException:
unknown local exception:
Ice::UnsupportedEncodingException
Ice.UnsupportedEncodingException
    reason = (null)
    badMajor = 1
    badMinor = 1
    major = 1
    minor = 0
    at IceInternal.BasicStream.startReadEncaps(BasicStream.java:298)
    at Ice.ObjectImpl.___ice_isA(ObjectImpl.java:91)
    at jderobot._CameraDisp.__dispatch(_CameraDisp.java:224)
    at IceInternal.Incoming.invoke(Incoming.java:159)
    at Ice.ConnectionI.invokeAll(ConnectionI.java:2357)
    at Ice.ConnectionI.dispatch(ConnectionI.java:1208)
    at Ice.ConnectionI.message(ConnectionI.java:1163)
    at IceInternal.ThreadPool.run(ThreadPool.java:302)
    at IceInternal.ThreadPool.access$300(ThreadPool.java:12)
    at IceInternal.ThreadPool$EventHandlerThread.run(ThreadPool.java:643)
    at java.lang.Thread.run(Thread.java:841)
```
